### PR TITLE
Fix leaf vm cache

### DIFF
--- a/tearup.yaml
+++ b/tearup.yaml
@@ -342,7 +342,7 @@
 
       - name: Cache leaf gateway VMs
         set_fact:
-          leaf_vms: '{{ dict(leaf_vm_create_result.results | map("json_query", "[async_result_item.item.name, openstack]") | list) }}'
+          leaf_vms: '{{ dict(leaf_vm_create_result.results | map("json_query", "[async_result_item.item, openstack]") | list) }}'
           cacheable: true
       when: leaf_vms is not defined
 


### PR DESCRIPTION
item.name doesn't exist, so they were all lumped together under "null"