### PR TITLE
leafs: sysctl: disable send_redirects

### DIFF
--- a/tearup.yaml
+++ b/tearup.yaml
@@ -576,6 +576,16 @@
         state: present
         reload: yes
 
+    - name: disable send_redirects
+      sysctl:
+        # eth1 is the gateway interface for leaf hosts
+        name: net.ipv4.conf.eth1.send_redirects
+        value: '0'
+        sysctl_set: yes
+        sysctl_file: /etc/sysctl.d/90-network.conf
+        state: present
+        reload: yes
+
     - name: Install frr
       ansible.builtin.package:
         name: frr


### PR DESCRIPTION
`send_redirects` should enabled only if the leaf router is the only host providing routing in the network/subnet.
However, we have custom routing rules on each host where the VIP lives
(ip rule & ip route, in a specific table), so the packets from the VIP
leaving the host are forced to go through the gateway.

For that reason, we don't want the router to send redirects and let the
router takes care of handling the packets for the VIP.

It's a complicated scenario because the VIP is not part of the same
subnet, but shares the same L2 segment; so we have to do routing (L3)
for packets that come in and go out.
