### PR TITLE
tearup/leafs: add sysctl for `fib_multipath_hash_policy`

### DIFF
--- a/tearup.yaml
+++ b/tearup.yaml
@@ -718,6 +718,12 @@
         enabled: yes
         state: restarted
 
+    # Use Layer 4 for load-balancing
+    - ansible.posix.sysctl:
+        name: net.ipv4.fib_multipath_hash_policy
+        value: '1'
+        state: present
+
 - hosts: vips
   gather_facts: false
 


### PR DESCRIPTION
Like we do for the Spine, configure `fib_multipath_hash_policy` in Layer
4 mode for the hash policy to use for multipath routes.

This will help to load-balance the traffic for the VIPs in the leafs.
