### PR TITLE
spine: restrict POSTROUTING on external nic

### DIFF
--- a/tearup.yaml
+++ b/tearup.yaml
@@ -547,6 +547,7 @@
         table: nat
         chain: POSTROUTING
         jump: SNAT
+        out_interface: "{{ ansible_facts.default_ipv4.interface }}"
         to_source: "{{ ansible_facts.default_ipv4.address }}"
 
     - name: Persist SNAT rule


### PR DESCRIPTION
The nat rule for postrouting is only useful when leaving the internal
network, not between the leafs.
So we'll restrict the nat rules to happen only for traffic on the
external interface.